### PR TITLE
Move wiki link to top of list. Add "LArSoft.org"

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,10 +5,10 @@ google-site-verification-chg: mWu4AzUH2LiVvIlufi6W4Goyu4kKB0pKde6qTj8XYoU
 # LArSoft Documentation
 
 
-* The [LArSoft Collaboration](https://larsoft.org/)
-* The [LArSoft github organization](https://github.com/LArSoft)
 * [LArSoft wiki](LArSoftWiki/)  
    * [original redmine wiki](https://cdcvs.fnal.gov/redmine/projects/larsoft/wiki)
+* [LArSoft.org:  The LArSoft Collaboration](https://larsoft.org/)
+* The [LArSoft github organization](https://github.com/LArSoft)
 * [Notes about updating these pages](update_wiki)
 * [Notes about the migration from redmine](https://github.com/LArSoft/laradmin/wiki/migration-notes.md)
 


### PR DESCRIPTION
For the GitHub Pages landing page, make the link to LArSoftWiki the first line, since people may end up here while trying to navigate through the former wiki pages. 

Having breadcrumbs would be helpful. We should look into the various options for implementing those.